### PR TITLE
Fix issue: Potential Signature Replay Attack

### DIFF
--- a/packages/contracts/contracts/BIP20/BIP20DelegatedTransfer.sol
+++ b/packages/contracts/contracts/BIP20/BIP20DelegatedTransfer.sol
@@ -26,10 +26,12 @@ contract BIP20DelegatedTransfer is BIP20, IBIP20DelegatedTransfer {
         address from,
         address to,
         uint256 amount,
+        uint256 expiry,
         bytes calldata signature
     ) external override returns (bool) {
-        bytes32 dataHash = keccak256(abi.encode(block.chainid, address(this), from, to, amount, nonce[from]));
+        bytes32 dataHash = keccak256(abi.encode(block.chainid, address(this), from, to, amount, nonce[from], expiry));
         require(ECDSA.recover(ECDSA.toEthSignedMessageHash(dataHash), signature) == from, "Invalid signature");
+        require(expiry > block.timestamp, "Expired signature");
 
         super._transfer(from, to, amount);
         nonce[from]++;

--- a/packages/contracts/contracts/BIP20/BIP20DelegatedTransfer.sol
+++ b/packages/contracts/contracts/BIP20/BIP20DelegatedTransfer.sol
@@ -28,7 +28,7 @@ contract BIP20DelegatedTransfer is BIP20, IBIP20DelegatedTransfer {
         uint256 amount,
         bytes calldata signature
     ) external override returns (bool) {
-        bytes32 dataHash = keccak256(abi.encode(from, to, amount, block.chainid, nonce[from]));
+        bytes32 dataHash = keccak256(abi.encode(block.chainid, address(this), from, to, amount, nonce[from]));
         require(ECDSA.recover(ECDSA.toEthSignedMessageHash(dataHash), signature) == from, "Invalid signature");
 
         super._transfer(from, to, amount);

--- a/packages/contracts/contracts/BIP20/IBIP20DelegatedTransfer.sol
+++ b/packages/contracts/contracts/BIP20/IBIP20DelegatedTransfer.sol
@@ -10,6 +10,7 @@ interface IBIP20DelegatedTransfer is IBIP20 {
         address from,
         address to,
         uint256 amount,
+        uint256 expiry,
         bytes calldata signature
     ) external returns (bool);
 }

--- a/packages/contracts/src/utils/ContractUtils.ts
+++ b/packages/contracts/src/utils/ContractUtils.ts
@@ -96,11 +96,12 @@ export class ContractUtils {
         from: string,
         to: string,
         amount: BigNumberish,
-        nonce: BigNumberish
+        nonce: BigNumberish,
+        expiry: number
     ): Uint8Array {
         const encodedResult = defaultAbiCoder.encode(
-            ["uint256", "address", "address", "address", "uint256", "uint256"],
-            [chainId, tokenAddress, from, to, amount, nonce]
+            ["uint256", "address", "address", "address", "uint256", "uint256", "uint256"],
+            [chainId, tokenAddress, from, to, amount, nonce, expiry]
         );
         return arrayify(keccak256(encodedResult));
     }

--- a/packages/contracts/src/utils/ContractUtils.ts
+++ b/packages/contracts/src/utils/ContractUtils.ts
@@ -91,15 +91,16 @@ export class ContractUtils {
     }
 
     public static getTransferMessage(
+        chainId: BigNumberish,
+        tokenAddress: string,
         from: string,
         to: string,
         amount: BigNumberish,
-        chainId: BigNumberish,
         nonce: BigNumberish
     ): Uint8Array {
         const encodedResult = defaultAbiCoder.encode(
-            ["address", "address", "uint256", "uint256", "uint256"],
-            [from, to, amount, chainId, nonce]
+            ["uint256", "address", "address", "address", "uint256", "uint256"],
+            [chainId, tokenAddress, from, to, amount, nonce]
         );
         return arrayify(keccak256(encodedResult));
     }

--- a/packages/contracts/test/DelegatedTransfer.test.ts
+++ b/packages/contracts/test/DelegatedTransfer.test.ts
@@ -159,10 +159,11 @@ describe("Test for LYT token", () => {
         const amount = BOACoin.make(500).value;
         const nonce = await token.nonceOf(account4.address);
         const message = ContractUtils.getTransferMessage(
+            ethers.provider.network.chainId,
+            token.address,
             account4.address,
             account5.address,
             amount,
-            ethers.provider.network.chainId,
             nonce
         );
         const signature = ContractUtils.signMessage(account3, message);
@@ -175,10 +176,11 @@ describe("Test for LYT token", () => {
         const amount = BOACoin.make(500).value;
         const nonce = await token.nonceOf(account4.address);
         const message = ContractUtils.getTransferMessage(
+            ethers.provider.network.chainId,
+            token.address,
             account4.address,
             account5.address,
             amount,
-            ethers.provider.network.chainId,
             nonce
         );
         const signature = ContractUtils.signMessage(account4, message);


### PR DESCRIPTION
Recommendation
Recommend including the token address in the dataHash as well to avoid signature reuse. Also, for better security practices, it is recommended to add expiry time as well for the signature.